### PR TITLE
Remove connection string from `appsettings.dev`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ In this demo, the premise is to have an AI Agent automatically create an Umbraco
 1. Clone/Fork this repo and open in VS Code.
 1. The Umbraco website needs to be running/installed: `dotnet run --project src/MyProject/MyProject.csproj`
 1. Ensure Umbraco MCP config is correct in the file: `/.rulesync/.mcp.json`
+1. [Create an Umbraco API User](https://docs.umbraco.com/umbraco-cms/fundamentals/data/users/api-users), with credentials matching your `/.rulesync/.mcp.json` file
 1. Run Rulesync: `npx rulesync generate --targets "*" --features "*"`
 1. Run a slash command like: `/01-umbhomepage` to get AI to do some work.
 

--- a/src/MyProject/appsettings.json
+++ b/src/MyProject/appsettings.json
@@ -29,9 +29,5 @@
         "AllowConcurrentLogins": false
       }
     }
-  },
-  "ConnectionStrings": {
-    "umbracoDbDSN": "Data Source=|DataDirectory|/Umbraco.sqlite.db;Cache=Shared;Foreign Keys=True;Pooling=True",
-    "umbracoDbDSN_ProviderName": "Microsoft.Data.Sqlite"
   }
 }


### PR DESCRIPTION
I needed to remove this connection string to launch the site with `dotnet run --project src/MyProject/MyProject.csproj`

Pointed users to the Umb docs for creating a credentialed API user